### PR TITLE
[API-1477] Don't post duplicate messages to a thread with multiple targets

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -142,6 +142,22 @@ jobs:
           thread_subject: CI workflow for $CIRCLE_SHA1
           custom: |
             **Message 2.**
+      - glue/notify:
+          debug: true
+          step_name: "Notify in a new thread with multiple targets"
+          event: always
+          thread_by: testing-multiple-$CIRCLE_SHA1
+          thread_subject: CI multiple targets workflow for $CIRCLE_SHA1
+          target: $GLUE_DEFAULT_TARGET,$GLUE_SECOND_TARGET
+          custom: |
+            **Message 3.** $CIRCLE_JOB
+      - glue/notify:
+          debug: true
+          step_name: "Notify multiple targets only"
+          event: always
+          target: $GLUE_DEFAULT_TARGET,$GLUE_SECOND_TARGET
+          custom: |
+            **Message 4.** $CIRCLE_JOB
 
 workflows:
   test-deploy:
@@ -169,7 +185,7 @@ executors:
       - image: cimg/base:current
   mac:
     macos:
-      xcode: 14.0.0
+      xcode: 14.3.1
   alpine:
     # This image contains both CURL and JQ
     docker:

--- a/src/examples/notify_thread.yml
+++ b/src/examples/notify_thread.yml
@@ -3,7 +3,7 @@ description: |
   `thread_subject` parameter determines the subject of the thread.
   `thread_by` parameter holds a thread identifier in case there are multiple notifications in the pipeline.
 
-  Note: target must be a group(s) if a thread is specified.
+  Note: target must be a group(s) if a `thread_subject` is specified.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/notify_thread.yml
+++ b/src/examples/notify_thread.yml
@@ -2,6 +2,8 @@ description: |
   Create a Glue thread in the `target` group and send subsequent `notify` messages to the same thread.
   `thread_subject` parameter determines the subject of the thread.
   `thread_by` parameter holds a thread identifier in case there are multiple notifications in the pipeline.
+
+  Note: target must be a group(s) if a thread is specified.
 usage:
   version: 2.1
   orbs:

--- a/src/examples/notify_two_targets.yml
+++ b/src/examples/notify_two_targets.yml
@@ -1,7 +1,7 @@
 description: |
   Send a Glue notification to two targets simultaneously.
   By default, if no target parameter is set, the $GLUE_DEFAULT_TARGET value will be used (must be set).
-  A custom target, or comma-separated list of targets can be supplied via the "target" parameter.
+  A custom target, or comma-separated list of targets (no spaces) can be supplied via the "target" parameter.
 
   It is recommended to use the "target ID" for the value(s).
 usage:
@@ -16,7 +16,7 @@ usage:
       steps:
         - glue/notify:
             event: always
-            target: grp_ABCXYZ, grp_ZXCVBN
+            target: grp_ABCXYZ,grp_ZXCVBN
             custom: |
               **This is a text notification**
   workflows:

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -58,13 +58,9 @@ BuildMessageBody() {
   GLUE_MSG_BODY="$T2"
 }
 
-PostToGlue() {
-  # Post once per target listed by the target parameter
-  #    The target must be modified in GLUE_MSG_BODY
-  # shellcheck disable=SC2001
-  for i in $(eval echo \""$GLUE_PARAM_TARGET"\" | sed "s/,/ /g"); do
-    echo "Sending to Glue Target: $i"
-    GLUE_MSG_BODY=$(echo "$GLUE_MSG_BODY" | jq --arg target "$i" '.target = $target')
+SendToTarget() {
+    echo "Sending to Glue Target: $1"
+    GLUE_MSG_BODY=$(echo "$GLUE_MSG_BODY" | jq --arg target "$1" '.target = $target')
     if [ "$GLUE_PARAM_DEBUG" -eq 1 ]; then
       printf "%s\n" "$GLUE_MSG_BODY" >"$GLUE_MSG_BODY_LOG"
       echo "The message body being sent to Glue can be found below. To view redacted values, rerun the job with SSH and access: ${GLUE_MSG_BODY_LOG}"
@@ -89,7 +85,20 @@ PostToGlue() {
         exit 1
       fi
     fi
-  done
+}
+
+PostToGlue() {
+  if [ -n "${GLUE_PARAM_THREAD_SUBJECT:-}" ] || [ -n "${GLUE_PARAM_THREAD_BY:-}" ]; then
+    # Posting to a thread, don't loop through targets
+    SendToTarget "$(eval echo "${GLUE_PARAM_TARGET}")"
+  else 
+    # Post once per target listed by the target parameter
+    #    The target must be modified in GLUE_MSG_BODY
+    # shellcheck disable=SC2001
+    for i in $(eval echo \""$GLUE_PARAM_TARGET"\" | sed "s/,/ /g"); do
+      SendToTarget "$i"
+    done
+  fi
 }
 
 InstallJq() {


### PR DESCRIPTION
API-1477

When using `glue/notify` for posting to a thread with multiple targets, we were getting duplicate messages being posted in the thread due to the notify script looping through the targets and calling `curl` to the webhook for each target. This adds a check to only do the loop when thread subject and threadBy are not provided, otherwise making a single call to the webhook for threads.